### PR TITLE
Hide specialties in stylist selection

### DIFF
--- a/src/components/StylistSelectionScreen.jsx
+++ b/src/components/StylistSelectionScreen.jsx
@@ -55,9 +55,6 @@ export default function StylistSelectionScreen() {
             >
               <div>
                 <h3 className="text-lg font-medium">{st.name}</h3>
-                <p className="text-gray-500 text-sm">
-                  Especialidades: {st.specialties.join(', ')}
-                </p>
               </div>
               <button
                 onClick={() =>


### PR DESCRIPTION
## Summary
- remove listing of stylist specialties in the selection screen

## Testing
- `npm install`
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_687715a150a0832797c64b67ebbe8ebe