### PR TITLE
Use adminEmail in tenant for admin rights

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ VITE_FIREBASE_APP_ID=XXXX
 
 ### Configuración de clientes (tenants)
 
-Crea una colección `tenants` en Firestore donde cada documento represente un cliente. El ID del documento será el *slug* utilizado en la URL y debe incluir al menos los campos `companyId` y `projectName`:
+Crea una colección `tenants` en Firestore donde cada documento represente un cliente. El ID del documento será el *slug* utilizado en la URL y debe incluir al menos los campos `companyId`, `projectName` y `adminEmail`:
 
 ```text
 tenants/
-  barberia1 { companyId: "c1", projectName: "Barbería 1" }
-  barberia2 { companyId: "c2", projectName: "Barbería 2" }
+  barberia1 { companyId: "c1", projectName: "Barbería 1", adminEmail: "admin1@example.com" }
+  barberia2 { companyId: "c2", projectName: "Barbería 2", adminEmail: "admin2@example.com" }
 ```
 
 Al acceder a `agendarturnos.ar/{cliente}` la aplicación cargará estos datos y los usará para filtrar la información.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -46,10 +46,14 @@ export default function App() {
 function AppContent() {
   const { user, profile } = useAuth();
   const location         = useLocation();
-  const { slug, projectName, companyId } = useTenant();
+  const { slug, projectName, adminEmail } = useTenant();
   // usados para mostrar/ocultar el panel admin
   const isTenantAdmin    =
-    profile?.isAdmin === true && profile?.companyId === companyId;
+    profile?.isAdmin === true &&
+    user?.email &&
+    (Array.isArray(adminEmail)
+      ? adminEmail.includes(user.email)
+      : user.email === adminEmail);
 
   const baseBtn =
     "px-3 py-1 rounded-full text-sm font-medium bg-white text-gray-800 border border-gray-300 hover:bg-gray-50 transition";


### PR DESCRIPTION
## Summary
- allow admin access by matching user email against `adminEmail` stored in tenant document
- document new `adminEmail` field in README

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68844874c474832790d6875e0d5bf040