### PR TITLE
Improve admin timeline layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@vitejs/plugin-react": "^3.1.0",
         "autoprefixer": "^10.0.0",
         "gh-pages": "^6.3.0",
-        "jest": "^29.0.0",
+        "jest": "^29.7.0",
         "postcss": "^8.0.0",
         "tailwindcss": "^3.0.0",
         "vite": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@vitejs/plugin-react": "^3.1.0",
     "autoprefixer": "^10.0.0",
     "gh-pages": "^6.3.0",
-    "jest": "^29.0.0",
+    "jest": "^29.7.0",
     "postcss": "^8.0.0",
     "tailwindcss": "^3.0.0",
     "vite": "^4.0.0"

--- a/src/components/AdminAppointmentsScreen.jsx
+++ b/src/components/AdminAppointmentsScreen.jsx
@@ -11,6 +11,7 @@ import {
 } from 'firebase/firestore';
 import { db } from '../firebaseConfig';
 import { useTenant } from '../TenantProvider';
+import TimelineChart from './TimelineChart';
 
 export default function AdminAppointmentsScreen({ appointments }) {
   const [selectedDate, setSelectedDate] = useState(null);
@@ -70,6 +71,7 @@ export default function AdminAppointmentsScreen({ appointments }) {
         <h3 className="text-xl font-semibold mb-4">
           Turnos para {prettyDate}
         </h3>
+        <TimelineChart appointments={list} userMap={userMap} />
 
         {/* Desktop */}
         <div className="hidden md:block overflow-x-auto">
@@ -91,9 +93,12 @@ export default function AdminAppointmentsScreen({ appointments }) {
               {list.map(appt => {
                 const user = userMap[appt.clientId] || {};
                 const dt = parseISO(appt.datetime);
+                const end = new Date(dt.getTime() + (appt.duration || 0) * 60000);
                 return (
                   <tr key={appt.id} className="border-b">
-                    <td className="px-4 py-2">{format(dt, 'HH:mm')}</td>
+                    <td className="px-4 py-2">
+                      {format(dt, 'HH:mm')} - {format(end, 'HH:mm')}
+                    </td>
                     <td className="px-4 py-2">{appt.stylistName}</td>
                     <td className="px-4 py-2">{appt.serviceName}</td>
                     <td className="px-4 py-2">
@@ -166,7 +171,9 @@ export default function AdminAppointmentsScreen({ appointments }) {
                 className="bg-white rounded-lg shadow p-4 space-y-2"
               >
                 <div className="flex justify-between">
-                  <span className="font-semibold">{format(dt, 'HH:mm')}</span>
+                  <span className="font-semibold">
+                    {format(dt, 'HH:mm')} - {format(new Date(dt.getTime() + (appt.duration || 0) * 60000), 'HH:mm')}
+                  </span>
                   <div className="flex space-x-2">
                     {usaConfirmacionSenia && !appt.depositConfirmed && (
                       <button

--- a/src/components/TimelineChart.jsx
+++ b/src/components/TimelineChart.jsx
@@ -1,0 +1,116 @@
+// src/components/TimelineChart.jsx
+import React, { useMemo } from 'react';
+import {
+  parseISO,
+  format,
+  startOfHour,
+  addHours,
+  addMinutes,
+  differenceInMinutes,
+} from 'date-fns';
+
+export default function TimelineChart({ appointments, userMap = {} }) {
+  const sorted = useMemo(
+    () => appointments.slice().sort((a, b) => new Date(a.datetime) - new Date(b.datetime)),
+    [appointments]
+  );
+
+  const start = useMemo(() => {
+    if (!sorted.length) return null;
+    return startOfHour(parseISO(sorted[0].datetime));
+  }, [sorted]);
+
+  const end = useMemo(() => {
+    if (!sorted.length) return null;
+    let lastEnd = parseISO(sorted[0].datetime);
+    sorted.forEach(appt => {
+      const st = parseISO(appt.datetime);
+      const en = new Date(st.getTime() + (appt.duration || 0) * 60000);
+      if (en > lastEnd) lastEnd = en;
+    });
+    return addHours(startOfHour(lastEnd), 1);
+  }, [sorted]);
+
+  const hours = useMemo(() => {
+    if (!start || !end) return [];
+    const arr = [];
+    let t = start;
+    while (t <= end) {
+      arr.push(t);
+      t = addHours(t, 1);
+    }
+    return arr;
+  }, [start, end]);
+
+  const halfHours = useMemo(() => {
+    if (!start || !end) return [];
+    const arr = [];
+    let t = start;
+    while (t <= end) {
+      arr.push(t);
+      t = addMinutes(t, 30);
+    }
+    return arr;
+  }, [start, end]);
+
+  const pxPerMinute = 4;
+  const totalMinutes = start && end ? differenceInMinutes(end, start) : 0;
+  const width = totalMinutes * pxPerMinute;
+
+  const offset = d => differenceInMinutes(d, start) * pxPerMinute;
+  const height = 48 + 32;
+
+  return (
+    <div className="overflow-x-auto mb-6">
+      <div className="relative" style={{ width, height }}>
+        {halfHours.map(h => (
+          <div
+            key={`half-${h.getTime()}`}
+            className="absolute border-l border-gray-100"
+            style={{ left: offset(h), top: 24, bottom: 0 }}
+          />
+        ))}
+        {hours.map(h => (
+          <React.Fragment key={h.getTime()}>
+            <div
+              className="absolute top-0 text-gray-500 text-xs"
+              style={{ left: offset(h) - 16 }}
+            >
+              {format(h, 'HH:mm')}
+            </div>
+            <div
+              className="absolute border-l border-gray-200"
+              style={{ left: offset(h), top: 16, bottom: 0 }}
+            />
+          </React.Fragment>
+        ))}
+
+        {sorted.map(appt => {
+          const st = parseISO(appt.datetime);
+          const en = new Date(st.getTime() + (appt.duration || 0) * 60000);
+          const left = offset(st);
+          const w = (appt.duration || 30) * pxPerMinute;
+          const top = 20;
+          const user = userMap[appt.clientId] || {};
+          const clientName = user.firstName
+            ? `${user.firstName} ${user.lastName}`
+            : appt.clientEmail;
+          return (
+            <div
+              key={appt.id}
+              className="absolute bg-blue-100 rounded p-2 text-xs shadow"
+              style={{ left, width: w, top }}
+            >
+              <div className="font-medium">
+                {format(st, 'HH:mm')} - {format(en, 'HH:mm')}
+              </div>
+              <div className="text-gray-700">
+                {appt.serviceName} - {clientName}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- keep appointment bars on a single horizontal row
- show the client's name on each bar
- pass userMap to timeline component
- add half-hour grid markers to the timeline

## Testing
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68844cec28a083279eceb15fd2866abe