### PR TITLE
Add payments tab for superadmin

### DIFF
--- a/src/routes/SuperAdminRouter.jsx
+++ b/src/routes/SuperAdminRouter.jsx
@@ -1,5 +1,13 @@
 import React, { useEffect, useState } from 'react';
-import { collection, onSnapshot, doc, setDoc, updateDoc, deleteDoc } from 'firebase/firestore';
+import {
+  collection,
+  onSnapshot,
+  doc,
+  setDoc,
+  updateDoc,
+  deleteDoc,
+  addDoc
+} from 'firebase/firestore';
 import { db } from '../firebaseConfig';
 import { useAuth } from '../AuthProvider';
 import { Navigate } from 'react-router-dom';
@@ -12,6 +20,9 @@ export default function SuperAdminRouter() {
   const [newTenant, setNewTenant] = useState({ slug: '', companyId: '', projectName: '' });
   const [search, setSearch] = useState('');
   const [editUser, setEditUser] = useState(null);
+  const [payments, setPayments] = useState([]);
+  const [newPayment, setNewPayment] = useState({ companyId: '', amount: '', paidAt: '', transferCode: '' });
+  const [paymentSearch, setPaymentSearch] = useState('');
 
   useEffect(() => {
     const unsub = onSnapshot(collection(db, 'tenants'), snap =>
@@ -23,6 +34,13 @@ export default function SuperAdminRouter() {
   useEffect(() => {
     const unsub = onSnapshot(collection(db, 'users'), snap =>
       setUsers(snap.docs.map(d => ({ id: d.id, ...d.data() })))
+    );
+    return unsub;
+  }, []);
+
+  useEffect(() => {
+    const unsub = onSnapshot(collection(db, 'payments'), snap =>
+      setPayments(snap.docs.map(d => ({ id: d.id, ...d.data() })))
     );
     return unsub;
   }, []);
@@ -67,9 +85,30 @@ export default function SuperAdminRouter() {
     setEditUser(null);
   };
 
+  const addPayment = async () => {
+    if (!newPayment.companyId || !newPayment.amount || !newPayment.paidAt) return;
+    await addDoc(collection(db, 'payments'), {
+      companyId: newPayment.companyId.trim(),
+      amount: parseFloat(newPayment.amount),
+      paidAt: new Date(newPayment.paidAt),
+      transferCode: newPayment.transferCode.trim()
+    });
+    setNewPayment({ companyId: '', amount: '', paidAt: '', transferCode: '' });
+  };
+
+  const deletePayment = async id => {
+    if (window.confirm('¿Eliminar pago?')) {
+      await deleteDoc(doc(db, 'payments', id));
+    }
+  };
+
   const filteredUsers = users.filter(u =>
     u.email?.toLowerCase().includes(search.toLowerCase()) ||
     `${u.firstName} ${u.lastName}`.toLowerCase().includes(search.toLowerCase())
+  );
+
+  const filteredPayments = payments.filter(p =>
+    p.companyId?.toLowerCase().includes(paymentSearch.toLowerCase())
   );
 
   return (
@@ -86,6 +125,12 @@ export default function SuperAdminRouter() {
           className={`px-4 py-2 rounded ${tab === 'users' ? 'bg-[#f1bc8a] text-white' : 'bg-gray-200'}`}
         >
           Permisos
+        </button>
+        <button
+          onClick={() => setTab('payments')}
+          className={`px-4 py-2 rounded ${tab === 'payments' ? 'bg-[#f1bc8a] text-white' : 'bg-gray-200'}`}
+        >
+          Pagos
         </button>
       </div>
 
@@ -197,6 +242,69 @@ export default function SuperAdminRouter() {
               </div>
             </div>
           )}
+        </div>
+      )}
+
+      {tab === 'payments' && (
+        <div className="space-y-4">
+          <input
+            className="border p-2 rounded w-full"
+            placeholder="Buscar companyId"
+            value={paymentSearch}
+            onChange={e => setPaymentSearch(e.target.value)}
+          />
+          <div className="flex space-x-2">
+            <input
+              className="border p-2 rounded"
+              placeholder="companyId"
+              value={newPayment.companyId}
+              onChange={e => setNewPayment({ ...newPayment, companyId: e.target.value })}
+            />
+            <input
+              type="number"
+              className="border p-2 rounded"
+              placeholder="Monto"
+              value={newPayment.amount}
+              onChange={e => setNewPayment({ ...newPayment, amount: e.target.value })}
+            />
+            <input
+              className="border p-2 rounded"
+              placeholder="Código de transferencia"
+              value={newPayment.transferCode}
+              onChange={e => setNewPayment({ ...newPayment, transferCode: e.target.value })}
+            />
+            <input
+              type="date"
+              className="border p-2 rounded"
+              value={newPayment.paidAt}
+              onChange={e => setNewPayment({ ...newPayment, paidAt: e.target.value })}
+            />
+            <button onClick={addPayment} className="px-3 py-2 bg-blue-500 text-white rounded">Agregar</button>
+          </div>
+          <table className="w-full border">
+            <thead>
+              <tr className="bg-gray-100">
+                <th className="border p-1">companyId</th>
+                <th className="border p-1">Monto</th>
+                <th className="border p-1">Código</th>
+                <th className="border p-1">Fecha</th>
+                <th className="border p-1">Acciones</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filteredPayments.map(p => (
+                <tr key={p.id}>
+                  <td className="border p-1">{p.companyId}</td>
+                  <td className="border p-1">{p.amount}</td>
+                  <td className="border p-1">{p.transferCode}</td>
+                  <td className="border p-1">{p.paidAt ? new Date(p.paidAt.seconds ? p.paidAt.seconds * 1000 : p.paidAt).toLocaleDateString() : ''}</td>
+                  <td className="border p-1">
+                    <button onClick={() => deletePayment(p.id)} className="px-2 py-1 bg-red-500 text-white rounded">Eliminar</button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- add Firestore `payments` collection listener
- manage payments (add/remove) from new tab
- include transfer code field and filter payments by company

## Testing
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6886cc5652208327b49d4d8c51ce68ff