### PR TITLE
feat: add professional role and filtering

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -100,6 +100,7 @@ exports.createTenant = functions.https.onRequest(async (req, res) => {
       email,
       companyId: companyId.trim(),
       isAdmin: true,
+      isProfesional: false,
       firstName: "",
       lastName: "",
       phone: "",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -47,8 +47,9 @@ function AppContent() {
   const { user, profile } = useAuth();
   const { slug, projectName, companyId } = useTenant();
   // usados para mostrar/ocultar el panel admin
-  const isTenantAdmin    =
-    profile?.isAdmin === true && profile?.companyId === companyId;
+  const canAccessAdmin =
+    (profile?.isAdmin || profile?.isProfesional) &&
+    profile?.companyId === companyId;
 
   return (
     <>
@@ -98,8 +99,8 @@ function AppContent() {
             path="admin/*"
             element={
               <RequireAuth>
-                {isTenantAdmin ? (
-                  <AdminRouter />
+                {canAccessAdmin ? (
+                  <AdminRouter profile={profile} />
                 ) : (
                   <Navigate to="" replace />
                 )}

--- a/src/components/AdminProfessionalScreen.jsx
+++ b/src/components/AdminProfessionalScreen.jsx
@@ -12,6 +12,7 @@ export default function AdminProfessionalScreen({
 
   const [name, setName] = useState('');
   const [alias, setAlias] = useState('');
+  const [email, setEmail] = useState('');
   const [selected, setSelected] = useState([]);
   const [schedule, setSchedule] = useState({});
   const [exceptions, setExceptions] = useState([]);
@@ -25,6 +26,7 @@ export default function AdminProfessionalScreen({
       if (prof) {
         setName(prof.name);
         setAlias(prof.alias || '');
+        setEmail(prof.email || '');
         setSelected(prof.specialties || []);
         setSchedule(
           Object.fromEntries(
@@ -122,6 +124,7 @@ export default function AdminProfessionalScreen({
   const resetForm = () => {
     setName('');
     setAlias('');
+    setEmail('');
     setSelected([]);
     setSchedule({});
     setExceptions([]);
@@ -132,6 +135,7 @@ export default function AdminProfessionalScreen({
     const data = {
       name,
       alias: alias.trim(),
+      email: email.trim(),
       specialties: selected,
       schedule,
       exceptions
@@ -170,6 +174,13 @@ export default function AdminProfessionalScreen({
           placeholder="Alias de pago"
           value={alias}
           onChange={e => setAlias(e.target.value)}
+          className="border p-2 w-full rounded"
+        />
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
           className="border p-2 w-full rounded"
         />
 
@@ -342,6 +353,9 @@ export default function AdminProfessionalScreen({
                   </p>
                   <p className="text-sm text-gray-500">
                     Alias de pago: {st.alias || '—'}
+                  </p>
+                  <p className="text-sm text-gray-500">
+                    Email: {st.email || '—'}
                   </p>
                 </div>
                 <div className="space-x-2">

--- a/src/components/AdminTabs.jsx
+++ b/src/components/AdminTabs.jsx
@@ -6,6 +6,7 @@ import AdminAppointmentsScreen from './AdminAppointmentsScreen';
 import AdminCategoryScreen     from './AdminCategoryScreen';
 
 export default function AdminTabs({
+  profile,
   services,
   stylists,
   appointments,
@@ -20,38 +21,45 @@ export default function AdminTabs({
   onUpdateCategory,
   onDeleteCategory
 }) {
-  const [tab, setTab] = useState('services');
+  const isAdmin = profile?.isAdmin;
+  const [tab, setTab] = useState(isAdmin ? 'services' : 'appointments');
 
   return (
     <div className="p-2">
       <div className="flex flex-wrap space-x-2 mb-4">
-        <button
-          onClick={() => setTab('services')}
-          className={`px-4 py-2 my-2 rounded ${tab === 'services' ? 'bg-[#f1bc8a] text-white' : 'bg-gray-200'}`}
-        >
-          Servicios
-        </button>
-        <button
-          onClick={() => setTab('professionals')}
-          className={`px-4 py-2 my-2 rounded ${tab === 'professionals' ? 'bg-[#f1bc8a] text-white' : 'bg-gray-200'}`}
-        >
-          Profesionales
-        </button>
+        {isAdmin && (
+          <button
+            onClick={() => setTab('services')}
+            className={`px-4 py-2 my-2 rounded ${tab === 'services' ? 'bg-[#f1bc8a] text-white' : 'bg-gray-200'}`}
+          >
+            Servicios
+          </button>
+        )}
+        {isAdmin && (
+          <button
+            onClick={() => setTab('professionals')}
+            className={`px-4 py-2 my-2 rounded ${tab === 'professionals' ? 'bg-[#f1bc8a] text-white' : 'bg-gray-200'}`}
+          >
+            Profesionales
+          </button>
+        )}
         <button
           onClick={() => setTab('appointments')}
           className={`px-4 py-2 my-2 rounded ${tab === 'appointments' ? 'bg-[#f1bc8a] text-white' : 'bg-gray-200'}`}
         >
           Turnos
         </button>
-        <button
-          onClick={() => setTab('categories')}
-          className={`px-4 py-2 my-2 rounded ${tab === 'categories' ? 'bg-[#f1bc8a] text-white' : 'bg-gray-200'}`}
-        >
-          Categorías
-        </button>
+        {isAdmin && (
+          <button
+            onClick={() => setTab('categories')}
+            className={`px-4 py-2 my-2 rounded ${tab === 'categories' ? 'bg-[#f1bc8a] text-white' : 'bg-gray-200'}`}
+          >
+            Categorías
+          </button>
+        )}
       </div>
       <div>
-        {tab === 'services' && (
+        {tab === 'services' && isAdmin && (
           <AdminServiceScreen
             services={services}
             categories={categories}
@@ -60,7 +68,7 @@ export default function AdminTabs({
             onDeleteService={onDeleteService}
           />
         )}
-        {tab === 'professionals' && (
+        {tab === 'professionals' && isAdmin && (
           <AdminProfessionalScreen
             services={services}
             stylists={stylists}
@@ -71,11 +79,12 @@ export default function AdminTabs({
         )}
         {tab === 'appointments' && (
           <AdminAppointmentsScreen
+            profile={profile}
             stylists={stylists}
             appointments={appointments}
           />
         )}
-        {tab === 'categories' && (
+        {tab === 'categories' && isAdmin && (
           <AdminCategoryScreen
             categories={categories}
             onAdd={onAddCategory}

--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -41,7 +41,8 @@ export default function Login() {
           lastName:  lastName.trim(),
           phone:     `${phoneCode}${phoneArea}${phone.trim()}`,
           email:     email.trim(),
-          isAdmin:   false
+          isAdmin:   false,
+          isProfesional: false
         });
       } else {
         await signInWithEmailAndPassword(auth, email, password);

--- a/src/components/MainNavbar.jsx
+++ b/src/components/MainNavbar.jsx
@@ -12,8 +12,9 @@ export default function MainNavbar() {
   );
   const { user, profile } = useAuth();
   const { slug, projectName, companyId } = useTenant();
-  const isTenantAdmin =
-    profile?.isAdmin === true && profile?.companyId === companyId;
+  const isTenantStaff =
+    (profile?.isAdmin || profile?.isProfesional) &&
+    profile?.companyId === companyId;
 
   // Listen for viewport changes to update isDesktop
   useEffect(() => {
@@ -72,7 +73,7 @@ export default function MainNavbar() {
                     Mi Perfil
                   </Link>
                 </li>
-                {isTenantAdmin && (
+                {isTenantStaff && (
                   <li className="nav-item">
                     <Link
                       className="nav-link"

--- a/src/routes/SuperAdminRouter.jsx
+++ b/src/routes/SuperAdminRouter.jsx
@@ -74,13 +74,14 @@ export default function SuperAdminRouter() {
   };
 
   const saveUser = async () => {
-    const { firstName, lastName, phone, companyId, isAdmin } = editUser;
+    const { firstName, lastName, phone, companyId, isAdmin, isProfesional } = editUser;
     await updateDoc(doc(db, 'users', editUser.id), {
       firstName: firstName || '',
       lastName: lastName || '',
       phone: phone || '',
       companyId: companyId || '',
-      isAdmin: !!isAdmin
+      isAdmin: !!isAdmin,
+      isProfesional: !!isProfesional
     });
     setEditUser(null);
   };
@@ -235,6 +236,16 @@ export default function SuperAdminRouter() {
                   onChange={e => setEditUser({ ...editUser, isAdmin: e.target.checked })}
                 />
                 <span>Es admin</span>
+              </label>
+              <label className="flex items-center space-x-2">
+                <input
+                  type="checkbox"
+                  checked={editUser.isProfesional || false}
+                  onChange={e =>
+                    setEditUser({ ...editUser, isProfesional: e.target.checked })
+                  }
+                />
+                <span>Es profesional</span>
               </label>
               <div className="space-x-2">
                 <button onClick={saveUser} className="px-3 py-1 bg-blue-500 text-white rounded">Guardar</button>


### PR DESCRIPTION
## Summary
- allow professional role accounts with limited admin access
- let admins filter appointments by professional and register stylist emails
- store professional flag on users and add email field for stylists

## Testing
- `npm test` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68981336d0048327a75e3df2a850071f