### PR TITLE
Sync professional accounts by email

### DIFF
--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -7,7 +7,7 @@ import {
   createUserWithEmailAndPassword
 } from 'firebase/auth';
 import { auth, db } from '../firebaseConfig';
-import { doc, setDoc } from 'firebase/firestore';
+import { doc, setDoc, collection, query, where, getDocs, updateDoc } from 'firebase/firestore';
 import { COUNTRY_CODES, AREA_CODES } from '../data/phone';
 
 export default function Login() {
@@ -44,6 +44,12 @@ export default function Login() {
           isAdmin:   false,
           isProfesional: false
         });
+        const profSnap = await getDocs(
+          query(collection(db, 'stylists'), where('email', '==', email.trim()))
+        );
+        if (!profSnap.empty) {
+          await updateDoc(doc(db, 'users', uid), { isProfesional: true });
+        }
       } else {
         await signInWithEmailAndPassword(auth, email, password);
       }

--- a/src/routes/AdminRouter.jsx
+++ b/src/routes/AdminRouter.jsx
@@ -9,7 +9,8 @@ import {
   doc,
   query,
   where,
-  onSnapshot
+  onSnapshot,
+  getDocs
 } from 'firebase/firestore';
 import { db } from '../firebaseConfig';
 import { useTenant } from '../TenantProvider';
@@ -102,12 +103,34 @@ export default function AdminRouter({ profile }) {
       ...data,
       companyId: companyId
     });
+    if (data.email) {
+      const q = query(collection(db, 'users'), where('email', '==', data.email));
+      const snap = await getDocs(q);
+      await Promise.all(
+        snap.docs.map(u =>
+          u.data().isProfesional
+            ? Promise.resolve()
+            : updateDoc(u.ref, { isProfesional: true })
+        )
+      );
+    }
   };
   const handleUpdateProfessional = async (id, data) => {
     await updateDoc(doc(db, 'stylists', id), {
       ...data,
       companyId: companyId
     });
+    if (data.email) {
+      const q = query(collection(db, 'users'), where('email', '==', data.email));
+      const snap = await getDocs(q);
+      await Promise.all(
+        snap.docs.map(u =>
+          u.data().isProfesional
+            ? Promise.resolve()
+            : updateDoc(u.ref, { isProfesional: true })
+        )
+      );
+    }
   };
   const handleDeleteProfessional = async id => {
     await deleteDoc(doc(db, 'stylists', id));


### PR DESCRIPTION
## Summary
- Mark existing users as professionals when adding or editing a stylist with the same email
- Set new users as professionals during registration if their email already belongs to a stylist
- Add Firebase functions to keep `users` and `stylists` collections in sync

## Testing
- `npm test` *(fails: No tests found, exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_689944d67784832785fa7a21aa7c4fad