### PR TITLE
Validate tenant slugs with regex

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -76,9 +76,19 @@ exports.createTenant = functions.https.onRequest(async (req, res) => {
     return;
   }
   try {
-    const { slug, companyId, projectName, email, password } = req.body;
-    if (!slug || !companyId || !email || !password) {
-      res.status(400).send("Missing fields");
+    const { slug: rawSlug, companyId: rawCompanyId, projectName, email, password } = req.body;
+    const slug = (rawSlug || "").trim().toLowerCase();
+    const companyId = (rawCompanyId || "").trim().toLowerCase();
+    const slugRegex = /^[a-z0-9-]{3,}$/;
+    if (
+      !slug ||
+      !companyId ||
+      !email ||
+      !password ||
+      !slugRegex.test(slug) ||
+      !slugRegex.test(companyId)
+    ) {
+      res.status(400).send("Invalid or missing fields");
       return;
     }
     const docRef = db.collection("tenants").doc(slug);
@@ -89,7 +99,7 @@ exports.createTenant = functions.https.onRequest(async (req, res) => {
     }
     // create tenant document
     await docRef.set({
-      companyId: companyId.trim(),
+      companyId,
       projectName: projectName || "",
     });
     // create auth user
@@ -98,7 +108,7 @@ exports.createTenant = functions.https.onRequest(async (req, res) => {
     await db.collection("users").doc(userRecord.uid).set({
       uid: userRecord.uid,
       email,
-      companyId: companyId.trim(),
+      companyId,
       isAdmin: true,
       isProfesional: false,
       firstName: "",

--- a/src/components/TenantSignup.jsx
+++ b/src/components/TenantSignup.jsx
@@ -23,6 +23,7 @@ export default function TenantSignup() {
   const [confirmedPayment, setConfirmedPayment] = useState(false);
 
   const mpLink = import.meta.env.VITE_MERCADOPAGO_LINK || "https://mpago.la/1NLEpxk";
+  const slugRegex = /^[a-z0-9-]{3,}$/;
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -42,6 +43,13 @@ export default function TenantSignup() {
       setLoading(false);
       return;
     }
+    const cleanSlug = slug.trim().toLowerCase();
+    if (!slugRegex.test(cleanSlug)) {
+      setMessage("Slug inválido");
+      setIsError(true);
+      setLoading(false);
+      return;
+    }
 
     try {
       // 1) Crear cuenta Auth
@@ -50,9 +58,9 @@ export default function TenantSignup() {
 
       // 2) Guardar tenant
       await setDoc(
-        doc(db, "tenants", slug.trim()),
+        doc(db, "tenants", cleanSlug),
         {
-          companyId: slug.trim(),
+          companyId: cleanSlug,
           projectName: projectName.trim(),
           ownerUid: uid,
           ownerEmail: email.trim(),
@@ -69,7 +77,7 @@ export default function TenantSignup() {
           lastName: lastName.trim(),
           phone: `${phoneCode}${phoneArea}${phone.trim()}`,
           email: email.trim(),
-          companyId: slug.trim(),
+          companyId: cleanSlug,
           isAdmin: true,
           createdAt: new Date(),
         }
@@ -79,7 +87,7 @@ export default function TenantSignup() {
       setIsError(false);
 
       // Redirigir tras 5s
-      const newSlug = slug.trim();
+      const newSlug = cleanSlug;
       setTimeout(() => navigate(`/${newSlug}`), 3000);
 
       // Reset campos
@@ -107,7 +115,9 @@ export default function TenantSignup() {
   };
 
   const handleSlugChange = (e) => {
-    const v = e.target.value.replace(/\s+/g, "");
+    const v = e.target.value
+      .toLowerCase()
+      .replace(/[^a-z0-9-]/g, "");
     setSlug(v);
   };
 


### PR DESCRIPTION
## Summary
- enforce strict tenant slug pattern in Cloud Function
- validate and sanitize tenant slug client-side during signup

## Testing
- `npm test -- --passWithNoTests`
- `node - <<'NODE'
const slugRegex=/^[a-z0-9-]{3,}$/;
function fakeCreateTenant(slug){
  const s=(slug||'').trim().toLowerCase();
  if(!slugRegex.test(s)) return 'rejected';
  return 'accepted';
}
['valid-slug','ab','bad!','otro_valido'].forEach(s=>console.log(s,fakeCreateTenant(s)));
NODE`


------
https://chatgpt.com/codex/tasks/task_e_689948426b248327b7a4a0647298f41d