### PR TITLE
Restrict Firestore writes to admin

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,4 +1,7 @@
 {
+  "firestore": {
+    "rules": "firestore.rules"
+  },
   "functions": [
     {
       "source": "functions",

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,28 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    function isAdmin() {
+      return request.auth != null &&
+        (request.auth.token.email == 'admin@agendarturnos.ar' ||
+         request.auth.token.role == 'admin');
+    }
+
+    match /tenants/{document=**} {
+      allow read: if request.auth != null;
+      allow write: if isAdmin();
+    }
+
+    match /users/{document=**} {
+      allow read: if request.auth != null;
+      allow write: if isAdmin();
+    }
+
+    match /payments/{document=**} {
+      allow read, write: if isAdmin();
+    }
+
+    match /{document=**} {
+      allow read, write: if request.auth != null;
+    }
+  }
+}

--- a/functions/index.js
+++ b/functions/index.js
@@ -71,6 +71,25 @@ exports.sendAppointmentReminders = functions.pubsub
   });
 
 exports.createTenant = functions.https.onRequest(async (req, res) => {
+  const authHeader = req.headers.authorization || "";
+  if (!authHeader.startsWith("Bearer ")) {
+    res.status(401).send("Unauthorized");
+    return;
+  }
+  try {
+    const idToken = authHeader.split("Bearer ")[1];
+    const decoded = await admin.auth().verifyIdToken(idToken);
+    if (
+      decoded.email !== "admin@agendarturnos.ar" &&
+      decoded.role !== "admin"
+    ) {
+      res.status(403).send("Forbidden");
+      return;
+    }
+  } catch (err) {
+    res.status(401).send("Unauthorized");
+    return;
+  }
   if (req.method !== "POST") {
     res.status(405).send("Method Not Allowed");
     return;


### PR DESCRIPTION
## Summary
- Lock down Firestore rules so tenants, users, and payments can only be modified by the admin email or role
- Include Firestore rules in firebase.json for deployment
- Secure createTenant cloud function by verifying requester is admin

## Testing
- `npm test` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_6899485900a08327a6fdaca44bc70324