### PR TITLE
Add plan-specific signup flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,15 @@ Para habilitar la integración con Mercado Pago agrega tu token de acceso:
 firebase functions:config:set mercadopago.token="TU_ACCESS_TOKEN"
 ```
 
-Y define la URL de pago que se mostrará en el formulario de alta:
+Y define las URLs de pago que se mostrarán en el formulario de alta para
+cada plan:
 
 ```bash
-echo "VITE_MERCADOPAGO_LINK=TU_LINK_DE_PAGO" > .env
+echo "VITE_MP_STANDARD_LINK=LINK_STANDARD"   > .env
+echo "VITE_MP_AVANZADO_LINK=LINK_AVANZADO" >> .env
+echo "VITE_MP_ILIMITADO_LINK=LINK_ILIMITADO" >> .env
+# Enlace de pago genérico opcional
+echo "VITE_MERCADOPAGO_LINK=LINK_POR_DEFECTO" >> .env
 ```
 
 El formulario de alta para nuevos tenants solicitará además del `slug` un `companyId` (identificador de la empresa),

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -29,7 +29,7 @@ export default function App() {
       <Router>
         <Routes>
           <Route path="/login" element={<PortalLogin />} />
-          <Route path="/alta" element={<TenantSignup />} />
+          <Route path="/alta/:plan?" element={<TenantSignup />} />
           <Route path="/super/*" element={<SuperAdminRouter />} />
           <Route
             path="/:tenant/*"

--- a/src/components/TenantSignup.jsx
+++ b/src/components/TenantSignup.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { createUserWithEmailAndPassword } from "firebase/auth";
 import { auth, db } from "../firebaseConfig";
 import { doc, setDoc } from "firebase/firestore";
@@ -7,6 +7,7 @@ import { COUNTRY_CODES, AREA_CODES } from "../data/phone";
 
 export default function TenantSignup() {
   const navigate = useNavigate();
+  const { plan } = useParams();
   const [slug, setSlug] = useState("");
   const [projectName, setProjectName] = useState("");
   const [firstName, setFirstName] = useState("");
@@ -22,7 +23,29 @@ export default function TenantSignup() {
   const [isError, setIsError] = useState(false);
   const [confirmedPayment, setConfirmedPayment] = useState(false);
 
-  const mpLink = import.meta.env.VITE_MERCADOPAGO_LINK || "https://mpago.la/1NLEpxk";
+  const plans = {
+    standard: {
+      label: "standard",
+      link:
+        import.meta.env.VITE_MP_STANDARD_LINK || "https://mpago.la/standard",
+    },
+    avanzado: {
+      label: "avanzado",
+      link:
+        import.meta.env.VITE_MP_AVANZADO_LINK || "https://mpago.la/avanzado",
+    },
+    ilimitado: {
+      label: "ilimitado",
+      link:
+        import.meta.env.VITE_MP_ILIMITADO_LINK || "https://mpago.la/ilimitado",
+    },
+  };
+
+  const selectedPlan = plans[plan];
+  const mpLink =
+    selectedPlan?.link ||
+    import.meta.env.VITE_MERCADOPAGO_LINK ||
+    "https://mpago.la/1NLEpxk";
   const slugRegex = /^[a-z0-9-]{3,}$/;
 
   const handleSubmit = async (e) => {
@@ -123,7 +146,9 @@ export default function TenantSignup() {
 
   return (
     <div className="container mt-5" style={{ maxWidth: "400px" }}>
-      <h1 className="text-center mb-3">Crear Cuenta</h1>
+      <h1 className="text-center mb-3">
+        Crear Cuenta{selectedPlan ? ` plan ${selectedPlan.label}` : ""}
+      </h1>
 
       <form onSubmit={handleSubmit}>
 


### PR DESCRIPTION
## Summary
- Support optional plan parameter in `/alta/:plan` route
- Customize signup heading and payment link for standard, avanzado, and ilimitado plans
- Document plan-specific Mercado Pago links in README

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68996d2059648327a67f593586f15575