### PR TITLE
feat: toggle de seña configurable por admin

### DIFF
--- a/src/TenantProvider.jsx
+++ b/src/TenantProvider.jsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { doc, getDoc } from 'firebase/firestore';
+import { doc, onSnapshot } from 'firebase/firestore';
 import { db } from './firebaseConfig';
 
 const TenantContext = createContext(null);
@@ -15,15 +15,11 @@ export function TenantProvider({ children }) {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    async function fetchTenant() {
-      try {
-        const snap = await getDoc(doc(db, 'tenants', tenant));
-        setConfig(snap.exists() ? { slug: tenant, ...snap.data() } : null);
-      } finally {
-        setLoading(false);
-      }
-    }
-    fetchTenant();
+    const unsubscribe = onSnapshot(doc(db, 'tenants', tenant), snap => {
+      setConfig(snap.exists() ? { slug: tenant, ...snap.data() } : null);
+      setLoading(false);
+    });
+    return () => unsubscribe();
   }, [tenant]);
 
   if (loading) return <p className="p-4 text-center">Cargando...</p>;

--- a/src/components/AdminConfigScreen.jsx
+++ b/src/components/AdminConfigScreen.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { useTenant } from '../TenantProvider';
+import { db } from '../firebaseConfig';
+import { doc, updateDoc } from 'firebase/firestore';
+
+export default function AdminConfigScreen() {
+  const { slug, usaConfirmacionSenia } = useTenant();
+
+  const handleChange = async e => {
+    const checked = e.target.checked;
+    await updateDoc(doc(db, 'tenants', slug), {
+      usaConfirmacionSenia: checked
+    });
+  };
+
+  return (
+    <div className="p-4">
+      <label className="flex items-center space-x-2">
+        <input
+          type="checkbox"
+          checked={!!usaConfirmacionSenia}
+          onChange={handleChange}
+        />
+        <span>Trabajar con seña</span>
+      </label>
+    </div>
+  );
+}

--- a/src/components/AdminTabs.jsx
+++ b/src/components/AdminTabs.jsx
@@ -4,6 +4,7 @@ import AdminServiceScreen   from './AdminServiceScreen';
 import AdminProfessionalScreen from './AdminProfessionalScreen';
 import AdminAppointmentsScreen from './AdminAppointmentsScreen';
 import AdminCategoryScreen     from './AdminCategoryScreen';
+import AdminConfigScreen       from './AdminConfigScreen';
 
 export default function AdminTabs({
   profile,
@@ -57,6 +58,14 @@ export default function AdminTabs({
             Categorías
           </button>
         )}
+        {isAdmin && (
+          <button
+            onClick={() => setTab('config')}
+            className={`px-4 py-2 my-2 rounded ${tab === 'config' ? 'bg-[#f1bc8a] text-white' : 'bg-gray-200'}`}
+          >
+            Configuración
+          </button>
+        )}
       </div>
       <div>
         {tab === 'services' && isAdmin && (
@@ -92,6 +101,7 @@ export default function AdminTabs({
             onDelete={onDeleteCategory}
           />
         )}
+        {tab === 'config' && isAdmin && <AdminConfigScreen />}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- permitir que el admin active o desactive el uso de seña mediante un switch
- agregar nueva pestaña de Configuración al panel de administración
- escuchar cambios del inquilino en tiempo real para reflejar la configuración

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa9be0510c8327b4833f25ee8cfac4