### PR TITLE
Set company ID on new professionals

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -163,7 +163,11 @@ exports.markUserAsProfessional = functions.firestore
       .limit(1)
       .get();
     if (!profSnap.empty) {
-      await snap.ref.update({ isProfesional: true });
+      const profData = profSnap.docs[0].data();
+      await snap.ref.update({
+        isProfesional: true,
+        companyId: profData.companyId,
+      });
     }
     return null;
   });
@@ -180,8 +184,14 @@ exports.syncProfessionalEmail = functions.firestore
     if (userSnap.empty) return null;
     const batch = db.batch();
     userSnap.forEach((u) => {
-      if (!u.data().isProfesional) {
-        batch.update(u.ref, { isProfesional: true });
+      if (
+        !u.data().isProfesional ||
+        u.data().companyId !== after.companyId
+      ) {
+        batch.update(u.ref, {
+          isProfesional: true,
+          companyId: after.companyId,
+        });
       }
     });
     await batch.commit();

--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -48,7 +48,11 @@ export default function Login() {
           query(collection(db, 'stylists'), where('email', '==', email.trim()))
         );
         if (!profSnap.empty) {
-          await updateDoc(doc(db, 'users', uid), { isProfesional: true });
+          const profData = profSnap.docs[0].data();
+          await updateDoc(doc(db, 'users', uid), {
+            isProfesional: true,
+            companyId: profData.companyId
+          });
         }
       } else {
         await signInWithEmailAndPassword(auth, email, password);

--- a/src/routes/AdminRouter.jsx
+++ b/src/routes/AdminRouter.jsx
@@ -107,11 +107,13 @@ export default function AdminRouter({ profile }) {
       const q = query(collection(db, 'users'), where('email', '==', data.email));
       const snap = await getDocs(q);
       await Promise.all(
-        snap.docs.map(u =>
-          u.data().isProfesional
-            ? Promise.resolve()
-            : updateDoc(u.ref, { isProfesional: true })
-        )
+        snap.docs.map(u => {
+          const needsUpdate =
+            !u.data().isProfesional || u.data().companyId !== companyId;
+          return needsUpdate
+            ? updateDoc(u.ref, { isProfesional: true, companyId })
+            : Promise.resolve();
+        })
       );
     }
   };
@@ -124,11 +126,13 @@ export default function AdminRouter({ profile }) {
       const q = query(collection(db, 'users'), where('email', '==', data.email));
       const snap = await getDocs(q);
       await Promise.all(
-        snap.docs.map(u =>
-          u.data().isProfesional
-            ? Promise.resolve()
-            : updateDoc(u.ref, { isProfesional: true })
-        )
+        snap.docs.map(u => {
+          const needsUpdate =
+            !u.data().isProfesional || u.data().companyId !== companyId;
+          return needsUpdate
+            ? updateDoc(u.ref, { isProfesional: true, companyId })
+            : Promise.resolve();
+        })
       );
     }
   };


### PR DESCRIPTION
## Summary
- Ensure Cloud Functions assign `companyId` when matching professional emails
- Update admin and signup flows to tag professionals with company IDs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abccb94be88327ab1f2ed523df9402