### PR TITLE
Extiende calendario para mostrar próximas cuatro semanas

### DIFF
--- a/src/components/ProfessionalCalendarScreen.jsx
+++ b/src/components/ProfessionalCalendarScreen.jsx
@@ -26,11 +26,11 @@ export default function ProfessionalCalendarScreen() {
   const [selectedDate, setSelectedDate] = useState(null);
   const [slotsByDate, setSlotsByDate] = useState({});
 
-  // Memoizamos los próximos 7 días
-  const days = useMemo(
-    () => Array.from({ length: 7 }, (_, i) => addDays(startOfDay(new Date()), i)),
-    []
-  );
+  // Memoizamos las próximas 4 semanas (28 días)
+  const days = useMemo(() => {
+    const today = startOfDay(new Date());
+    return Array.from({ length: 28 }, (_, i) => addDays(today, i));
+  }, []);
 
   // Cargar citas existentes
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Generar días para el calendario de turnos abarcando las próximas 4 semanas

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad3a7b36948327ad94786dc54ec743