### PR TITLE
Reflect profile edits immediately after saving

### DIFF
--- a/src/AuthProvider.jsx
+++ b/src/AuthProvider.jsx
@@ -30,7 +30,7 @@ export function AuthProvider({ children }) {
   }, []);
 
   return (
-    <AuthContext.Provider value={{ user, profile, loading }}>
+    <AuthContext.Provider value={{ user, profile, setProfile, loading }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/components/MyProfileScreen.jsx
+++ b/src/components/MyProfileScreen.jsx
@@ -5,7 +5,7 @@ import { useAuth } from '../AuthProvider';
 import { COUNTRY_CODES, AREA_CODES } from '../data/phone';
 
 export default function MyProfileScreen() {
-  const { user, profile } = useAuth();
+  const { user, profile, setProfile } = useAuth();
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
   const [phoneCode, setPhoneCode] = useState(COUNTRY_CODES[0].code);
@@ -33,11 +33,13 @@ export default function MyProfileScreen() {
       return;
     }
     try {
-      await updateDoc(doc(db, 'users', user.uid), {
+      const updatedProfile = {
         firstName: firstName.trim(),
         lastName: lastName.trim(),
         phone: `${phoneCode}${phoneNumber.trim()}`,
-      });
+      };
+      await updateDoc(doc(db, 'users', user.uid), updatedProfile);
+      setProfile(prev => ({ ...prev, ...updatedProfile }));
       alert('Datos actualizados');
     } catch (err) {
       alert('Error al guardar');


### PR DESCRIPTION
## Summary
- Update auth context to expose `setProfile`
- Refresh profile state after saving edits so changes show without reloading

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4d4c98a38832793d3a00858839dff