### PR TITLE
Send email notifications for appointments

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -15,6 +15,44 @@ const mpClient = new MercadoPagoConfig({
 });
 const mpCustomer = new Customer(mpClient);
 
+exports.notifyAppointmentCreated = functions.firestore
+  .document("appointments/{id}")
+  .onCreate(async (snap) => {
+    const a = snap.data();
+    if (!a) return null;
+    const dt = a.datetime.toDate();
+    const fmt = dt.toLocaleString("es-AR", {
+      weekday: "long",
+      day: "numeric",
+      month: "long",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+    const messages = [];
+    if (a.clientEmail) {
+      messages.push({
+        to: a.clientEmail,
+        from: "no-reply@tusalon.com",
+        subject: "Confirmación de turno",
+        text: `Has reservado ${a.serviceName} con ${a.stylistName} el ${fmt}.`,
+        html: `<p>Has reservado <strong>${a.serviceName}</strong> con <strong>${a.stylistName}</strong> el <strong>${fmt}</strong>.</p>`,
+      });
+    }
+    if (a.stylistEmail) {
+      messages.push({
+        to: a.stylistEmail,
+        from: "no-reply@tusalon.com",
+        subject: "Nuevo turno reservado",
+        text: `${a.clientEmail} reservó ${a.serviceName} el ${fmt}.`,
+        html: `<p><strong>${a.clientEmail}</strong> reservó <strong>${a.serviceName}</strong> el <strong>${fmt}</strong>.</p>`,
+      });
+    }
+    if (messages.length > 0) {
+      await sgMail.send(messages);
+    }
+    return null;
+  });
+
 exports.sendAppointmentReminders = functions.pubsub
   .schedule("every 60 minutes")
   .onRun(async () => {

--- a/src/components/MyAppointmentsScreen.jsx
+++ b/src/components/MyAppointmentsScreen.jsx
@@ -30,7 +30,11 @@ export default function MyAppointmentsScreen() {
       const snap = await getDocs(q);
       const now = new Date();
       const data = snap.docs
-        .map(d => ({ id: d.id, ...d.data() }))
+        .map(d => ({
+          id: d.id,
+          ...d.data(),
+          datetime: d.data().datetime.toDate().toISOString(),
+        }))
         .filter(a => parseISO(a.datetime) >= now);
       data.sort((a, b) => parseISO(a.datetime) - parseISO(b.datetime));
       setAppointments(data);

--- a/src/components/ProfessionalCalendarScreen.jsx
+++ b/src/components/ProfessionalCalendarScreen.jsx
@@ -1,7 +1,7 @@
 // src/components/ProfessionalCalendarScreen.jsx
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { collection, getDocs, doc, runTransaction } from 'firebase/firestore';
+import { collection, getDocs, doc, runTransaction, Timestamp } from 'firebase/firestore';
 import { db, auth } from '../firebaseConfig';
 import {
   format,
@@ -43,7 +43,7 @@ export default function ProfessionalCalendarScreen() {
         setAppointments(
           snap.docs.map(d => ({
             id: d.id,
-            datetime: d.data().datetime,
+            datetime: d.data().datetime.toDate().toISOString(),
             duration: d.data().duration || service.duration,
             stylistId: d.data().stylistId
           }))
@@ -174,13 +174,15 @@ export default function ProfessionalCalendarScreen() {
           transaction.set(apptRef, {
             stylistId: stylist.id,
             stylistName: stylist.name,
+            stylistEmail: stylist.email || '',
             serviceId: service.id,
             serviceName: service.name,
             clientId: auth.currentUser.uid,
             clientEmail: auth.currentUser.email,
-            datetime: dt.toISOString(),
+            datetime: Timestamp.fromDate(dt),
             duration: service.duration,
             companyId: companyId,
+            reminderSent: false,
           });
         });
         alert('Turno reservado correctamente.');

--- a/src/routes/AdminRouter.jsx
+++ b/src/routes/AdminRouter.jsx
@@ -71,7 +71,11 @@ export default function AdminRouter({ profile }) {
       const today = new Date();
       today.setHours(0, 0, 0, 0);
       let list = snap.docs
-        .map(d => ({ id: d.id, ...d.data() }))
+        .map(d => ({
+          id: d.id,
+          ...d.data(),
+          datetime: d.data().datetime.toDate().toISOString(),
+        }))
         .filter(a => new Date(a.datetime) >= today);
       if (profile?.isProfesional && myStylistId) {
         list = list.filter(a => a.stylistId === myStylistId);


### PR DESCRIPTION
## Summary
- send confirmation emails to clients and professionals when a new appointment is created
- store appointment datetimes as Firestore Timestamps and include stylist email for reminders
- adjust admin and client screens to read Timestamp values correctly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4fccbd1708327bd09184cb34153b7