### PR TITLE
feat: open tutorial after tenant signup

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 // src/App.jsx
-import React from 'react';
+import React, { useEffect } from 'react';
 import {
   BrowserRouter as Router,
   Routes,
@@ -52,6 +52,16 @@ function AppContent() {
   const canAccessAdmin =
     (profile?.isAdmin || profile?.isProfesional) &&
     profile?.companyId === companyId;
+
+  useEffect(() => {
+    if (localStorage.getItem('showTutorial') === 'true') {
+      window.open(
+        'https://drive.google.com/file/d/12pJCHASdQmPoPAl_phxo4XU8lD6KYMad/view?usp=drive_link',
+        '_blank'
+      );
+      localStorage.removeItem('showTutorial');
+    }
+  }, []);
 
   return (
     <>

--- a/src/components/TenantSignup.jsx
+++ b/src/components/TenantSignup.jsx
@@ -109,6 +109,8 @@ export default function TenantSignup() {
       setMessage("Registro exitoso");
       setIsError(false);
 
+      localStorage.setItem('showTutorial', 'true');
+
       // Redirigir tras 5s
       const newSlug = cleanSlug;
       setTimeout(() => navigate(`/${newSlug}`), 3000);


### PR DESCRIPTION
## Summary
- show onboarding tutorial on first visit after signup
- flag signup completion to trigger tutorial popup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5239f2e6c832790fb41607f749186